### PR TITLE
Version bump: revert node version to 14 in version-bump.yml

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2 # Reverted to v2 temporarily
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "14"
           cache: "npm"
 
       - name: Install npm dependencies


### PR DESCRIPTION
Reverted node version back to 14 in the version-bump GitHub Actions workflow.